### PR TITLE
feat(auth): Implement Authorization via RBAC (RolesGuard & Decorator)

### DIFF
--- a/src/auth/decorators/roles.decorator.ts
+++ b/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from 'src/users/entities/user.entity';
+
+export const ROLES_KEY = 'roles';
+
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,26 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { User, UserRole } from 'src/users/entities/user.entity';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest<{ user: User }>();
+
+    if (!user) return false;
+
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,7 +1,20 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { UserRole } from './entities/user.entity';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get('admin-only')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  getAdminData() {
+    return {
+      message: 'Si ves esto, las guards de admin funcionan xd',
+    };
+  }
 }


### PR DESCRIPTION
- RolesGuard: Se creó el guard que verifica si el usuario tiene los privilegios necesarios.

- @Roles(): Se creó un decorador personalizado para asignar los roles permitidos a un controlador o método.

- Test Endpoint: Se agregó una ruta /users/admin-only para verificar que el bloqueo funciona correctamente.

Cómo usar: Para proteger una ruta, se debe usar JwtAuthGuard (para saber quién es) seguido de RolesGuard (para saber qué puede hacer), y definir los roles con el decorador:

@Get('ruta-protegida')
@UseGuards(JwtAuthGuard, RolesGuard) // ⚠️ El orden importa: JWT primero
@Roles(UserRole.ADMIN, UserRole.BRAND_ADMIN) // Solo Admins y Marcas pasan
metodoProtegido() {
  return "Acceso concedido";
}