### PR TITLE
refactor(products): optimize Material relationship (ManyToOne) & add catalog support

### DIFF
--- a/src/products/entities/material-composition.entity.ts
+++ b/src/products/entities/material-composition.entity.ts
@@ -1,47 +1,24 @@
-import { Product } from './product.entity';
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  ManyToOne,
-  JoinColumn,
-} from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { MaterialProduct } from './material-product.entity';
 
 @Entity({ name: 'material_compositions' })
 export class MaterialComposition {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
-  material: string;
-
-  @Column({
-    type: 'decimal',
-    precision: 5,
-    scale: 2,
-  })
-  percentage: number;
+  @Column({ unique: true }) // Importante: Nombres únicos
+  name: string; // Ej: 'Algodón Orgánico', 'Poliéster Reciclado'
 
   @Column({ default: false })
   isEcoFriendly: boolean;
 
-  @Column({
-    type: 'decimal',
-    precision: 10,
-    scale: 2,
-    default: 0,
-  })
-  carbonFootprint: number;
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  carbonFootprintPerKg: number; // Especificar la unidad ayuda al cálculo
 
-  @Column({
-    type: 'decimal',
-    precision: 10,
-    scale: 2,
-    default: 0,
-  })
-  waterUsage: number;
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  waterUsagePerKg: number;
 
-  @ManyToOne(() => Product, (product) => product.materialComposition)
-  @JoinColumn({ name: 'product_id' })
-  product: Product;
+  // Relación inversa: Un material puede estar en muchos 'MaterialProduct'
+  @OneToMany(() => MaterialProduct, (mp) => mp.materialComposition)
+  materialProducts: MaterialProduct[];
 }

--- a/src/products/entities/material-product.entity.ts
+++ b/src/products/entities/material-product.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Product } from './product.entity';
+import { MaterialComposition } from './material-composition.entity';
+
+@Entity({ name: 'material_products' })
+export class MaterialProduct {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'decimal', precision: 5, scale: 2 })
+  percentage: number;
+
+  @ManyToOne(
+    () => MaterialComposition,
+    (composition) => composition.materialProducts,
+  )
+  @JoinColumn({ name: 'composition_id' })
+  materialComposition: MaterialComposition;
+
+  @ManyToOne(() => Product, (product) => product.materials)
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+}

--- a/src/products/entities/product.entity.ts
+++ b/src/products/entities/product.entity.ts
@@ -15,6 +15,7 @@ import {
   JoinColumn,
   DeleteDateColumn,
 } from 'typeorm';
+import { MaterialProduct } from './material-product.entity';
 
 export enum RecyclabilityStatus {
   FULLY_RECYCLABLE = 'FULLY_RECYCLABLE',
@@ -69,10 +70,10 @@ export class Product {
   })
   enviromentalImpact: EnvironmentalImpact;
 
-  @OneToMany(() => MaterialComposition, (material) => material.product, {
+  @OneToMany(() => MaterialProduct, (material) => material.product, {
     cascade: true,
   })
-  materialComposition: MaterialComposition[];
+  materials: MaterialProduct[];
 
   @ManyToOne(() => Brand, (brand) => brand.products)
   @JoinColumn({ name: 'brand_id' })


### PR DESCRIPTION
Cambio de Relación (MaterialProduct):

Se cambió de @OneToOne a @ManyToOne hacia MaterialComposition.

Motivo: Esto permite que múltiples productos (a través de la tabla intermedia) apunten a una única definición de material (ej: ID de "Algodón Orgánico").

Mejora de Entidad (MaterialComposition):

Se añadió la columna name (unique: true).

Motivo: Necesitamos un nombre identificable para el material (ej: "Poliéster Reciclado") para que actúe como un catálogo maestro.

Limpieza (Product):

Se verificaron las importaciones y la cascada de las relaciones.