### PR TITLE
feat: Brand Business Analytics & Revenue Stats

### DIFF
--- a/src/brands/brands.module.ts
+++ b/src/brands/brands.module.ts
@@ -4,9 +4,10 @@ import { Brand } from './entities/brand.entity';
 import { BrandsService } from './brands.service';
 import { BrandsController } from './brands.controller';
 import { FilesModule } from 'src/files/files.module';
+import { Order } from 'src/orders/entities/order.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Brand]), FilesModule],
+  imports: [TypeOrmModule.forFeature([Brand, Order]), FilesModule],
   controllers: [BrandsController],
   providers: [BrandsService],
 })

--- a/src/brands/brands.service.ts
+++ b/src/brands/brands.service.ts
@@ -1,15 +1,23 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brand } from './entities/brand.entity';
 import { Repository } from 'typeorm';
 import { CreateBrandDto } from './dto/create-brand.dto';
 import { User } from 'src/users/entities/user.entity';
+import { Order, OrderStatus } from 'src/orders/entities/order.entity';
 
 @Injectable()
 export class BrandsService {
   constructor(
     @InjectRepository(Brand)
     private readonly brandRepository: Repository<Brand>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
   ) {}
 
   async create(createBrandDto: CreateBrandDto, user: User) {
@@ -38,5 +46,76 @@ export class BrandsService {
     return this.brandRepository.find({
       relations: ['owner', 'products'],
     });
+  }
+
+  async findBrandOrders(user: User) {
+    const brand = await this.brandRepository.findOne({
+      where: { owner: { id: user.id } },
+    });
+
+    if (!brand) {
+      throw new BadRequestException(
+        'No tienes una marca registrada para ver ventas.',
+      );
+    }
+
+    return this.orderRepository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.items', 'item')
+      .leftJoinAndSelect('item.product', 'product')
+      .leftJoinAndSelect('order.user', 'customer')
+      .where('product.brand_id = :brandId', { brandId: brand.id })
+      .andWhere('order.status != :pending', { pending: 'pending' })
+      .orderBy('order.createdAt', 'DESC')
+      .getMany();
+  }
+
+  async updateOrderStatus(orderId: string, status: OrderStatus, user: User) {
+    const brand = await this.brandRepository.findOne({
+      where: { owner: { id: user.id } },
+    });
+
+    if (!brand) throw new BadRequestException('Usuario sin marca.');
+
+    const order = await this.orderRepository
+      .createQueryBuilder('order')
+      .innerJoin('order.items', 'item')
+      .innerJoin('item.product', 'product')
+      .where('order.id = :orderId', { orderId })
+      .andWhere('product.brand_id = :brandId', { brandId: brand.id })
+      .getOne();
+
+    if (!order) {
+      throw new NotFoundException(
+        'Orden no encontrada o no contiene productos de tu marca.',
+      );
+    }
+
+    order.status = status;
+    return this.orderRepository.save(order);
+  }
+
+  async getBrandStats(user: User) {
+    const brand = await this.brandRepository.findOne({
+      where: { owner: { id: user.id } },
+    });
+    if (!brand) throw new BadRequestException('No tienes marca.');
+
+    const stats = await this.orderRepository
+      .createQueryBuilder('order')
+      .innerJoin('order.items', 'item')
+      .innerJoin('item.product', 'product')
+      .select('SUM(item.priceAtPurchase * item.quantity)', 'totalRevenue')
+      .addSelect('SUM(item.quantity)', 'totalUnitsSold')
+      .addSelect('COUNT(DISTINCT order.id)', 'totalOrders')
+      .where('product.brand_id = :brandId', { brandId: brand.id })
+      .andWhere('order.status != :pending', { pending: 'pending' })
+      .getRawOne();
+
+    return {
+      totalRevenue: Number(stats.totalRevenue) || 0,
+      totalUnitsSold: Number(stats.totalUnitsSold) || 0,
+      totalOrders: Number(stats.totalOrders) || 0,
+    };
   }
 }

--- a/src/brands/dto/brand-stats.dto.ts
+++ b/src/brands/dto/brand-stats.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BrandStatsDto {
+  @ApiProperty({
+    description:
+      'Ingresos totales generados por los productos de la marca (Suma de precios al momento de compra)',
+    example: 15400.5,
+  })
+  totalRevenue: number;
+
+  @ApiProperty({
+    description: 'Cantidad total de unidades de productos vendidas',
+    example: 340,
+  })
+  totalUnitsSold: number;
+
+  @ApiProperty({
+    description:
+      'Cantidad de órdenes únicas que contienen al menos un producto de la marca',
+    example: 45,
+  })
+  totalOrders: number;
+}

--- a/src/brands/dto/update-order-status.dto.ts
+++ b/src/brands/dto/update-order-status.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { OrderStatus } from 'src/orders/entities/order.entity';
+
+export class UpdateOrderStatusDto {
+  @ApiProperty({
+    description: 'Nuevo estado de la orden',
+    enum: OrderStatus,
+    example: OrderStatus.SHIPPED,
+  })
+  @IsNotEmpty()
+  @IsEnum(OrderStatus)
+  status: OrderStatus;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -42,16 +42,6 @@ export class UsersController {
     private readonly ordersService: OrdersService,
   ) {}
 
-  @Get('admin-only')
-  @ApiOperation({ summary: 'Endpoint de prueba para probar Guard de Roles.' })
-  @UseGuards(RolesGuard)
-  @Roles(UserRole.ADMIN)
-  getAdminData() {
-    return {
-      message: 'Si ves esto, las guards de admin funcionan xd',
-    };
-  }
-
   @Get('profile')
   @ApiOperation({ summary: 'Obtener perfil del usuario autenticado' })
   @ApiResponse({


### PR DESCRIPTION
Este PR habilita el Dashboard Comercial para los administradores de marca. Ahora, cada marca puede visualizar sus métricas financieras en tiempo real, resolviendo la complejidad de calcular ingresos dentro de un Marketplace donde una orden puede contener productos de múltiples vendedores.

Lógica de Negocio (BrandsService)

- Segregación de Ingresos: Se implementó una consulta SQL vía QueryBuilder que:
- Une Orders, OrderItems y Products.
- Filtra solo los ítems que pertenecen a la marca del usuario (product.brand_id).
- Filtra solo órdenes con estado PAID (Ingreso real).
- Suma priceAtPurchase * quantity para obtener el Revenue exacto, ignorando el precio de productos de otras marcas en la misma orden.

API (BrandsController)

- Nuevo Endpoint: GET /brands/dashboard/stats.
- Seguridad: Protegido para roles BRAND_ADMIN y ADMIN.
- Documentación: Se añadió BrandStatsDto para exponer el esquema de respuesta en Swagger.