### PR TITLE
feat(wallet): implementar arquitectura de eco-wallet y cálculo de puntos

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { TransformInterceptor } from './common/interceptors/transform.intercepto
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { MaterialCompositionModule } from './material-composition/material-composition.module';
+import { WalletModule } from './wallet/wallet.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { MaterialCompositionModule } from './material-composition/material-compo
     NotificationsModule,
     AdminModule,
     MaterialCompositionModule,
+    WalletModule,
   ],
   controllers: [],
   providers: [

--- a/src/wallet/controllers/wallet.controller.spec.ts
+++ b/src/wallet/controllers/wallet.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletController } from './wallet.controller';
+import { WalletService } from '../services/wallet.service';
+
+describe('WalletController', () => {
+  let controller: WalletController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WalletController],
+      providers: [WalletService],
+    }).compile();
+
+    controller = module.get<WalletController>(WalletController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/wallet/controllers/wallet.controller.ts
+++ b/src/wallet/controllers/wallet.controller.ts
@@ -1,0 +1,100 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { WalletService } from '../services/wallet.service';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { GetUser } from 'src/auth/decorators/get-user.decorator';
+import { User } from 'src/users/entities/user.entity';
+import { RedeemPointsDto } from '../dto/redeem-points.dto';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { CreateRewardDto } from '../dto/create-reward.dto';
+
+@ApiTags('Eco-Wallet')
+@Controller('wallet')
+export class WalletController {
+  constructor(private readonly walletService: WalletService) {}
+
+  @Get('balance')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: 'Obtener saldo actual, nivel y estado de la billetera',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Retorna el objeto wallet con el saldo y nivel actual.',
+  })
+  async getBlance(@GetUser() user: User) {
+    return this.walletService.getBalance(user.id);
+  }
+
+  @Get('history')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: 'Ver historial de transacciones (Ganancias y Canjes)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Lista de las últimas transacciones ordenadas por fecha.',
+  })
+  async getHistory(@GetUser() user: User) {
+    return this.walletService.getHistory(user.id);
+  }
+
+  @Post('redeem')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Canjear puntos por una recompensa' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Canje exitoso. Retorna el nuevo saldo y ID de transacción.',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNPROCESSABLE_ENTITY,
+    description: 'Error de negocio: Saldo insuficiente o Stock agotado.',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Error de validación o recompensa inactiva.',
+  })
+  async redeemPoints(
+    @GetUser() user: User,
+    @Body() redeemDto: RedeemPointsDto,
+  ) {
+    return this.walletService.redeemPoints(user.id, redeemDto);
+  }
+
+  @Get('rewards')
+  @ApiOperation({ summary: 'Listar catálogo de recompensas activas' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Lista de recompensas disponibles para canje.',
+  })
+  async getRewards() {
+    return this.walletService.findAllRewards();
+  }
+
+  @Post('rewards')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiOperation({ summary: 'Crear nueva recompensa (Solo Admin)' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Recompensa creada correctamente en el catálogo.',
+  })
+  async createReward(@Body() createRewardDto: CreateRewardDto) {
+    return this.walletService.createReward(createRewardDto);
+  }
+}

--- a/src/wallet/dto/create-reward.dto.ts
+++ b/src/wallet/dto/create-reward.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsString,
+  IsInt,
+  IsOptional,
+  IsEnum,
+  Min,
+  IsUrl,
+  IsBoolean,
+  IsNotEmpty,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RewardType } from '../entities/reward.entity';
+
+export class CreateRewardDto {
+  @ApiProperty({
+    description: 'Nombre de la recompensa',
+    example: 'Plantar un Árbol Nativo',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Descripción detallada',
+    example: 'Ayuda a reforestar la selva misionera con esta donación.',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({
+    description: 'Costo en puntos',
+    minimum: 1,
+    example: 500,
+  })
+  @IsInt()
+  @Min(1)
+  costInPoints: number;
+
+  @ApiPropertyOptional({
+    description: 'URL de la imagen ilustrativa',
+  })
+  @IsUrl()
+  @IsOptional()
+  imageUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Stock inicial (dejar vacío para ilimitado)',
+    example: 100,
+  })
+  @IsInt()
+  @IsOptional()
+  stock?: number;
+
+  @ApiProperty({
+    description: 'Tipo de recompensa',
+    enum: RewardType,
+    default: RewardType.DONATION,
+  })
+  @IsEnum(RewardType)
+  type: RewardType;
+
+  @ApiPropertyOptional({
+    description: 'Si la recompensa está activa inmediatamente',
+    default: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/src/wallet/dto/redeem-points.dto.ts
+++ b/src/wallet/dto/redeem-points.dto.ts
@@ -1,0 +1,21 @@
+import { IsUUID, IsInt, Min, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RedeemPointsDto {
+  @ApiProperty({
+    description: 'ID único de la recompensa o causa benéfica a canjear',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID('4', { message: 'El rewardId debe ser un UUID válido' })
+  @IsNotEmpty()
+  rewardId: string;
+
+  @ApiProperty({
+    description: 'Cantidad de puntos a utilizar en el canje',
+    minimum: 1,
+    example: 100,
+  })
+  @IsInt({ message: 'El monto debe ser un número entero' })
+  @Min(1, { message: 'El monto mínimo de canje es 1 punto' })
+  amount: number;
+}

--- a/src/wallet/entities/reward.entity.ts
+++ b/src/wallet/entities/reward.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum RewardType {
+  DONATION = 'DONATION',
+  COUPON = 'COUPON',
+  PRODUCT = 'PRODUCT',
+}
+
+@Entity('rewards')
+export class Reward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 150 })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'int' })
+  costInPoints: number;
+
+  @Column({ type: 'varchar', nullable: true })
+  imageUrl: string;
+
+  @Column({ type: 'int', nullable: true })
+  stock: number;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  // Tipo de recompensa para lógica de backend
+  // DONATION = Ejecuta lógica de donación
+  // COUPON = Genera código de descuento
+  @Column({
+    type: 'enum',
+    enum: RewardType,
+    default: RewardType.DONATION,
+  })
+  type: RewardType;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/wallet/entities/wallet-transaction.entity.ts
+++ b/src/wallet/entities/wallet-transaction.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Wallet } from './wallet.entity';
+
+export enum TransactionType {
+  EARN_PURCHASE = 'EARN_PURCHASE',
+  REDEEM_REWARD = 'REDEEM_REWARD',
+  ADJUSTMENT = 'ADJUSTMENT',
+  EXPIRE = 'EXPIRE',
+}
+
+@Entity('wallet_transactions')
+export class WalletTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Wallet, (wallet) => wallet.transactions, { nullable: false })
+  @JoinColumn({ name: 'walletId' })
+  wallet: Wallet;
+
+  @Column({ type: 'uuid' })
+  walletId: string;
+
+  @Column({ type: 'int' })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: TransactionType,
+  })
+  type: TransactionType;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  referenceId: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  description: string;
+
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>;
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date;
+}

--- a/src/wallet/entities/wallet.entity.ts
+++ b/src/wallet/entities/wallet.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  VersionColumn,
+} from 'typeorm';
+import { WalletTransaction } from './wallet-transaction.entity';
+
+@Entity('wallets')
+export class Wallet {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'int', default: 0 })
+  balance: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'Semilla' })
+  level: string;
+
+  @VersionColumn()
+  version: number;
+
+  @OneToMany(() => WalletTransaction, (transaction) => transaction.wallet)
+  transactions: WalletTransaction[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/wallet/listeners/order-paid.event.ts
+++ b/src/wallet/listeners/order-paid.event.ts
@@ -1,0 +1,6 @@
+export class OrderPaidWalletEvent {
+  orderId: string;
+  userId: string;
+  totalAmount: number;
+  totalCo2Saved: number;
+}

--- a/src/wallet/listeners/order-paid.listener.ts
+++ b/src/wallet/listeners/order-paid.listener.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WalletService } from '../services/wallet.service';
+import { PointsCalculatorService } from '../services/points-calculator.service';
+import { OrderPaidWalletEvent } from './order-paid.event';
+
+@Injectable()
+export class OrderPaidListener {
+  private readonly logger = new Logger(OrderPaidListener.name);
+
+  constructor(
+    private readonly walletService: WalletService,
+    private readonly pointsCalculator: PointsCalculatorService,
+  ) {}
+
+  @OnEvent('order.paid', { async: true })
+  async handleOrderPaidEvent(event: OrderPaidWalletEvent) {
+    const { userId, totalAmount, totalCo2Saved, orderId } = event;
+
+    this.logger.log(
+      `Procesando puntos para la orden ${orderId} del usuario ${userId}`,
+    );
+
+    try {
+      const wallet = await this.walletService.getBalance(userId);
+
+      const calculation = this.pointsCalculator.calculatePoints(
+        totalAmount,
+        totalCo2Saved,
+        wallet.level,
+      );
+
+      if (calculation.totalPoints > 0) {
+        await this.walletService.addPoints(
+          userId,
+          calculation.totalPoints,
+          `Premio por Orden #${orderId.slice(0, 8)}`,
+          {
+            orderId,
+            co2Saved: totalCo2Saved,
+            breakdown: calculation.breakdown,
+          },
+        );
+
+        this.logger.log(
+          `+${calculation.totalPoints} puntos acreditados al usuario ${userId}`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error procesando puntos para la orden ${orderId}`,
+        error.stack,
+      );
+    }
+  }
+}

--- a/src/wallet/services/points-calculator.service.ts
+++ b/src/wallet/services/points-calculator.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PointsCalculatorService {
+  private readonly POINTS_PER_DOLLAR = 1;
+  private readonly POINTS_PER_KG_CO2 = 20;
+
+  calculatePoints(
+    orderTotal: number,
+    co2SavedKg: number,
+    userLevel: string = 'Semilla',
+  ): { totalPoints: number; breakdown: any } {
+    const pointsFromRevenue = Math.floor(orderTotal * this.POINTS_PER_DOLLAR);
+
+    const pointsFromImpact = Math.floor(co2SavedKg * this.POINTS_PER_KG_CO2);
+
+    const multiplier = this.getLevelMultiplier(userLevel);
+
+    const basePoints = pointsFromRevenue + pointsFromImpact;
+    const finalPoints = Math.floor(basePoints * multiplier);
+
+    return {
+      totalPoints: finalPoints,
+      breakdown: {
+        pointsFromRevenue,
+        pointsFromImpact,
+        multiplier,
+        basePoints,
+        appliedLevel: userLevel,
+      },
+    };
+  }
+
+  private getLevelMultiplier(level: string): number {
+    switch (level?.toUpperCase()) {
+      case 'BROTE CONSCIENTE':
+        return 1.1;
+      case 'GUARDIÁN DEL BOSQUE':
+        return 1.25;
+      case 'HÉROE CLIMÁTICO':
+        return 1.5;
+      case 'SEMILLA':
+      default:
+        return 1.0;
+    }
+  }
+}

--- a/src/wallet/services/wallet.service.spec.ts
+++ b/src/wallet/services/wallet.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletService } from './wallet.service';
+
+describe('WalletService', () => {
+  let service: WalletService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WalletService],
+    }).compile();
+
+    service = module.get<WalletService>(WalletService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/wallet/services/wallet.service.ts
+++ b/src/wallet/services/wallet.service.ts
@@ -1,0 +1,148 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { Wallet } from '../entities/wallet.entity';
+import {
+  TransactionType,
+  WalletTransaction,
+} from '../entities/wallet-transaction.entity';
+import { Reward } from '../entities/reward.entity';
+import { RedeemPointsDto } from '../dto/redeem-points.dto';
+import { CreateRewardDto } from '../dto/create-reward.dto';
+
+@Injectable()
+export class WalletService {
+  constructor(
+    @InjectRepository(Wallet)
+    private readonly walletRepository: Repository<Wallet>,
+    @InjectRepository(WalletTransaction)
+    private readonly walletTransactionRepository: Repository<WalletTransaction>,
+    @InjectRepository(Reward)
+    private readonly rewardRepository: Repository<Reward>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async getBalance(userId: string): Promise<Wallet> {
+    let wallet = await this.walletRepository.findOne({ where: { userId } });
+
+    if (!wallet) {
+      wallet = this.walletRepository.create({
+        userId,
+        balance: 0,
+        level: 'Semilla',
+      });
+      await this.walletRepository.save(wallet);
+    }
+
+    return wallet;
+  }
+
+  async getHistory(userId: string) {
+    const wallet = await this.getBalance(userId);
+
+    return this.walletTransactionRepository.find({
+      where: { walletId: wallet.id },
+      order: { createdAt: 'DESC' },
+      take: 20,
+    });
+  }
+
+  async addPoints(
+    userId: string,
+    amount: number,
+    description: string,
+    metadata?: any,
+  ) {
+    if (amount <= 0) throw new BadRequestException('Amount must be positive');
+
+    await this.dataSource.transaction(async (manager) => {
+      let wallet = await manager.findOne(Wallet, { where: { userId } });
+      if (!wallet) {
+        wallet = manager.create(Wallet, { userId, balance: 0 });
+        await manager.save(wallet);
+      }
+
+      wallet.balance += amount;
+      await manager.save(wallet);
+
+      const tx = manager.create(WalletTransaction, {
+        wallet,
+        amount,
+        type: TransactionType.EARN_PURCHASE,
+        description,
+        metadata,
+      });
+      await manager.save(tx);
+    });
+
+    return { success: true, pointsAdded: amount };
+  }
+
+  async redeemPoints(userId: string, redeemDto: RedeemPointsDto) {
+    const { rewardId, amount } = redeemDto;
+
+    return await this.dataSource.transaction(async (manager) => {
+      const reward = await manager.findOne(Reward, { where: { id: rewardId } });
+      if (!reward) throw new NotFoundException('Reward not found');
+      if (!reward.isActive)
+        throw new BadRequestException('Reward is not active');
+
+      const cost = reward.costInPoints;
+      if (amount < cost) {
+        throw new BadRequestException(`This reward costs ${cost} points`);
+      }
+
+      const wallet = await manager.findOne(Wallet, { where: { userId } });
+      if (!wallet) throw new NotFoundException('Wallet not found for user.');
+
+      if (wallet.balance < amount) {
+        throw new UnprocessableEntityException(
+          `Insufficient funds. Balance: ${wallet.balance}, Required: ${amount}`,
+        );
+      }
+
+      if (reward.stock !== null) {
+        if (reward.stock <= 0)
+          throw new UnprocessableEntityException('Reward out of stock');
+        reward.stock -= 1;
+        await manager.save(reward);
+      }
+
+      wallet.balance -= amount;
+
+      await manager.save(wallet);
+
+      const tx = manager.create(WalletTransaction, {
+        wallet,
+        amount: -amount,
+        type: TransactionType.REDEEM_REWARD,
+        referenceId: rewardId,
+        description: `Canje: ${reward.name}`,
+        metadata: { rewardId: reward.id, rewardName: reward.name },
+      });
+      await manager.save(tx);
+
+      return {
+        success: true,
+        transactionId: tx.id,
+        spentPoints: amount,
+        newBalance: wallet.balance,
+        rewardName: reward.name,
+      };
+    });
+  }
+
+  async createReward(createRewardDto: CreateRewardDto) {
+    const reward = this.rewardRepository.create(createRewardDto);
+    return this.rewardRepository.save(reward);
+  }
+
+  async findAllRewards() {
+    return this.rewardRepository.find({ where: { isActive: true } });
+  }
+}

--- a/src/wallet/wallet.module.ts
+++ b/src/wallet/wallet.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { WalletService } from './services/wallet.service';
+import { WalletController } from './controllers/wallet.controller';
+import { PointsCalculatorService } from './services/points-calculator.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Wallet } from './entities/wallet.entity';
+import { Reward } from './entities/reward.entity';
+import { WalletTransaction } from './entities/wallet-transaction.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Wallet, Reward, WalletTransaction])],
+  controllers: [WalletController],
+  providers: [WalletService, PointsCalculatorService],
+})
+export class WalletModule {}


### PR DESCRIPTION
- Se crearon entidades Wallet, WalletTransaction y Reward con soporte para Optimistic Locking.
- Se implementó WalletService para gestión transaccional de saldo y canjes.
- Se agregaron PointsCalculatorService con lógica de negocio basada en ahorro de CO2 y niveles de usuario.
- Se expuso endpoints REST en WalletController (balance, historial, redeem).
- Implementación de patrón Observer con OrderPaidListener para desacoplar la asignación de puntos.
- Integración emisión del evento 'order.paid' en OrdersService tras pago exitoso.