### PR TITLE
feat(products): Automatizar cálculo de recyclabilityStatus basado en materiales

### DIFF
--- a/src/products/dto/product.dto.ts
+++ b/src/products/dto/product.dto.ts
@@ -90,14 +90,6 @@ export class CreateProductDto {
   @Type(() => Number)
   weightKg: number;
 
-  @ApiProperty({
-    description: 'Estado de reciclabilidad',
-    enum: RecyclabilityStatus,
-    example: RecyclabilityStatus.FULLY_RECYCLABLE,
-  })
-  @IsEnum(RecyclabilityStatus)
-  recyclabilityStatus: RecyclabilityStatus;
-
   @ApiPropertyOptional({
     description: 'Texto alternativo para la imagen',
     example: 'Camisa blanca...',

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -108,6 +108,11 @@ export class ProductsService {
 
       await queryRunner.manager.save(materialProducts);
 
+      product.recyclabilityStatus =
+        this.productsHelper.calculateRecyclabilityStatus(materialProducts);
+
+      await queryRunner.manager.save(product);
+
       const impactEntity = this.productsHelper.createEnvironmentalImpactEntity(
         environmentalImpact,
         product,


### PR DESCRIPTION
## Cambios

- Se eliminó el campo `recyclabilityStatus` de `CreateProductDto` para garantizar la integridad de los datos y evitar inconsistencias por entrada manual.
- Implementación de método `calculateRecyclabilityStatus` en `ProductsHelper` que determina el nivel (FULLY, PARTIALLY, NON_RECYCLABLE) según el porcentaje de materiales `isEcoFriendly`.
- Integración de la lógica de cálculo en `ProductsService` (métodos `create` y `update`) para que el estado se asigne automáticamente tras procesar la composición de materiales.