### PR TITLE
feat(api): panel de admin para órdenes, corrección de métricas de marca y gestión de wallet

### DIFF
--- a/src/brands/brands.controller.ts
+++ b/src/brands/brands.controller.ts
@@ -64,7 +64,7 @@ export class BrandsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Ver órdenes que contienen mis productos' })
   async getMyOrders(@GetUser() user: User) {
-    return this.brandsService.findBrandOrders(user);
+    return this.brandsService.findBrandOrders(user.id);
   }
 
   @Patch('orders/:id/status')
@@ -107,6 +107,6 @@ export class BrandsController {
     description: 'Acceso denegado (Requiere rol BRAND_ADMIN o ADMIN).',
   })
   async getBrandStats(@GetUser() user: User) {
-    return this.brandsService.getBrandStats(user);
+    return this.brandsService.getBrandStats(user.id);
   }
 }

--- a/src/brands/brands.module.ts
+++ b/src/brands/brands.module.ts
@@ -5,9 +5,10 @@ import { BrandsService } from './brands.service';
 import { BrandsController } from './brands.controller';
 import { FilesModule } from 'src/files/files.module';
 import { Order } from 'src/orders/entities/order.entity';
+import { OrderItem } from 'src/orders/entities/order-item.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Brand, Order]), FilesModule],
+  imports: [TypeOrmModule.forFeature([Brand, Order, OrderItem]), FilesModule],
   controllers: [BrandsController],
   providers: [BrandsService],
   exports: [BrandsService],

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,10 +1,12 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { GetUser } from 'src/auth/decorators/get-user.decorator';
-import { User } from 'src/users/entities/user.entity';
+import { User, UserRole } from 'src/users/entities/user.entity';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
 
 @ApiTags('Órdenes de Compra')
 @ApiBearerAuth()
@@ -23,5 +25,18 @@ export class OrdersController {
   @ApiOperation({ summary: 'Historial de compras del usuario' })
   findAll(@GetUser() user: User) {
     return this.ordersService.findAll(user);
+  }
+
+  @Get('orders')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Listar todas las órdenes de la plataforma (Paginado)',
+  })
+  async getAllOrders(
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
+    return this.ordersService.findAllOrdersAdmin(Number(page), Number(limit));
   }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -131,4 +131,24 @@ export class OrdersService {
       nextGoal,
     };
   }
+
+  async findAllOrdersAdmin(page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+
+    const [orders, total] = await this.orderRepository.findAndCount({
+      relations: ['user', 'items', 'items.product'],
+      order: { createdAt: 'DESC' },
+      take: limit,
+      skip: skip,
+    });
+
+    return {
+      data: orders,
+      meta: {
+        total,
+        page,
+        lastPage: Math.ceil(total / limit),
+      },
+    };
+  }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -65,7 +65,7 @@ export class UsersController {
     return this.usersService.update(userId, updateUserDto);
   }
 
-  @Post('profile/image')
+  @Patch('profile/image')
   @ApiOperation({
     summary: 'Actualizar foto de perfil',
     description:

--- a/src/wallet/controllers/wallet.controller.ts
+++ b/src/wallet/controllers/wallet.controller.ts
@@ -1,9 +1,12 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
+  Param,
   Post,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { WalletService } from '../services/wallet.service';
@@ -16,10 +19,12 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { GetUser } from 'src/auth/decorators/get-user.decorator';
-import { User } from 'src/users/entities/user.entity';
+import { User, UserRole } from 'src/users/entities/user.entity';
 import { RedeemPointsDto } from '../dto/redeem-points.dto';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { CreateRewardDto } from '../dto/create-reward.dto';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { AdjustPointsDto } from '../dto/adjust-points.dto';
 
 @ApiTags('Eco-Wallet')
 @Controller('wallet')
@@ -116,5 +121,24 @@ export class WalletController {
   })
   async getMyCoupons(@GetUser() user: User) {
     return this.walletService.getMyCoupons(user.id, true);
+  }
+
+  @Post('points/adjust')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Ajustar manualmente los puntos de un usuario (Admin)',
+  })
+  async adjustPoints(@Body() adjustDto: AdjustPointsDto, @Req() req) {
+    const adminId = req.user.id;
+    return this.walletService.manualAdjustment(adminId, adjustDto);
+  }
+
+  @Delete('rewards/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Desactivar una recompensa' })
+  async deleteReward(@Param('id') id: string) {
+    return this.walletService.deleteReward(id);
   }
 }

--- a/src/wallet/dto/adjust-points.dto.ts
+++ b/src/wallet/dto/adjust-points.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString, IsUUID } from 'class-validator';
+
+export class AdjustPointsDto {
+  @ApiProperty({
+    description: 'ID del usuario a ajustar',
+    example: 'uuid-user',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({
+    description:
+      'Cantidad de puntos (Positivo para sumar, Negativo para restar)',
+    example: 100,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  amount: number;
+
+  @ApiProperty({
+    description: 'Razón del ajuste',
+    example: 'Compensación por error en orden #123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+}

--- a/src/wallet/services/wallet.service.ts
+++ b/src/wallet/services/wallet.service.ts
@@ -16,6 +16,7 @@ import { RedeemPointsDto } from '../dto/redeem-points.dto';
 import { CreateRewardDto } from '../dto/create-reward.dto';
 import { Coupon } from '../entities/coupon.entity';
 import * as crypto from 'crypto';
+import { AdjustPointsDto } from '../dto/adjust-points.dto';
 
 @Injectable()
 export class WalletService {
@@ -201,5 +202,29 @@ export class WalletService {
   private generateCouponCode(): string {
     const suffix = crypto.randomBytes(3).toString('hex').toUpperCase();
     return `ECO-${suffix}`;
+  }
+
+  async manualAdjustment(adminId: string, adjustDto: AdjustPointsDto) {
+    const { userId, amount, description } = adjustDto;
+
+    const result = await this.addPoints(
+      userId,
+      amount,
+      `AJUSTE ADMIN: ${description}`,
+      { adjustedBy: adminId },
+    );
+
+    return {
+      message: `Saldo ajustado en ${amount > 0 ? '+' : ''}${amount} puntos.`,
+      ...result,
+    };
+  }
+
+  async deleteReward(id: string) {
+    const reward = await this.rewardRepository.findOne({ where: { id } });
+    if (!reward) throw new NotFoundException('Recompensa no encontrada');
+
+    reward.isActive = false;
+    return await this.rewardRepository.save(reward);
   }
 }


### PR DESCRIPTION
# Cambios Principales
## 1. Módulo Admin & Orders:

Visión Global: Se creó el endpoint GET /admin/orders (paginado) que permite al Admin ver el historial completo de transacciones de la plataforma, independientemente de la marca.

## 2. Módulo Brands (Fix):

Filtrado Real: Se refactorizó findBrandOrders para usar QueryBuilder y filtrar órdenes que contengan al menos un producto de la marca consultada.

Cálculo de Ingresos: Se corrigió getBrandStats. Antes podía sumar el total de la orden completa; ahora suma exclusivamente priceAtPurchase * quantity de los ítems pertenecientes a la marca.

## 3. Módulo Wallet (Admin Tools):

Ajuste Manual: Nuevo endpoint POST /wallet/points/adjust (solo Admin) para acreditar o debitar puntos a un usuario específico por incidencias o promociones manuales.

Gestión de Recompensas: Nuevo endpoint DELETE /wallet/rewards/:id que realiza un Soft Delete (isActive = false) para quitar recompensas del catálogo sin romper el historial de canjes.

# Cómo probar

## Admin Orders: 

Loguearse como ADMIN y consultar /admin/orders. Debería traer todas las ventas.

## Brand Stats:

Crear una orden con productos de la Marca A y la Marca B.

Consultar /brands/dashboard/stats con el usuario de la Marca A.

Verificar que el totalRevenue corresponda solo a sus productos, no al total de la orden.

## Wallet:

Usar el endpoint de ajuste para sumar 500 puntos a un usuario. Verificar su nuevo balance en /wallet/balance.

Eliminar una recompensa y verificar que ya no aparezca en el listado público /wallet/rewards.